### PR TITLE
Implement boiler restart service

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ An ESPHome external component for integrating with OpenTherm boilers using [Ihor
 - Control heating and hot water temperature setpoints
 - Monitor faults and diagnostics
 - Full integration with Home Assistant via ESPHome
+- Restart the boiler using a dedicated service
 
 ## Installation
 
@@ -80,6 +81,18 @@ opentherm:
     name: "Hot Water"
   heating_water_climate:
     name: "Central Heating"
+```
+
+### Restarting the Boiler
+
+The component exposes a `restart_boiler` service that sends a reset command to the boiler. You can call it from Home Assistant or define a template button:
+
+```yaml
+button:
+  - platform: template
+    name: "Boiler Restart"
+    on_press:
+      - opentherm.restart_boiler
 ```
 
 ## Wiring

--- a/build.yaml
+++ b/build.yaml
@@ -128,6 +128,10 @@ button:
   - platform: restart
     name: "${friendly_name} Restart"
     id: restart_button
+  - platform: template
+    name: "${friendly_name} Boiler Restart"
+    on_press:
+      - opentherm.restart_boiler
 
 # Add a couple of template sensors to show additional information (optional)
 sensor:

--- a/components/opentherm/__init__.py
+++ b/components/opentherm/__init__.py
@@ -3,7 +3,6 @@ import esphome.config_validation as cv
 from esphome.components import binary_sensor, sensor, climate
 from esphome.const import (
     CONF_ID,
-    CONF_TEMPERATURE,
     DEVICE_CLASS_HEAT,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_PRESSURE,
@@ -188,6 +187,9 @@ async def to_code(config):
         await climate.register_climate(heating_var, heating_conf)
         cg.add(heating_var.set_climate_type(ClimateType.HEATING_WATER))
         cg.add(var.register_climate(heating_var))
-    
+
     # Add library dependencies
     cg.add_library("ihormelnyk/OpenTherm Library", "1.1.4")
+
+    # Register restart_boiler service
+    cg.add(var.register_service("restart_boiler", {}, var.restart_boiler))

--- a/components/opentherm/binary_sensor.py
+++ b/components/opentherm/binary_sensor.py
@@ -5,7 +5,7 @@ from esphome.const import (
     DEVICE_CLASS_HEAT,
     DEVICE_CLASS_PROBLEM,
 )
-from . import opentherm_ns, OpenthermComponent, CONF_ID
+from . import OpenthermComponent, CONF_ID
 
 DEPENDENCIES = ["opentherm"]
 CODEOWNERS = ["@yourusername"]

--- a/components/opentherm/climate.py
+++ b/components/opentherm/climate.py
@@ -3,11 +3,6 @@ import esphome.config_validation as cv
 from esphome.components import climate
 from esphome.const import (
     CONF_ID,
-    CONF_MODE,
-    CONF_TARGET_TEMPERATURE,
-    CONF_TARGET_TEMPERATURE_HIGH,
-    CONF_TARGET_TEMPERATURE_LOW,
-    CONF_TEMPERATURE,
 )
 from . import opentherm_ns, OpenthermComponent, OpenthermClimate
 

--- a/components/opentherm/opentherm_component.cpp
+++ b/components/opentherm/opentherm_component.cpp
@@ -197,6 +197,14 @@ namespace esphome
       return ot_->isValidResponse(response) ? ot_->getFloat(response) : NAN;
     }
 
+    bool OpenthermComponent::restart_boiler()
+    {
+      // Send command 1 which most boilers interpret as a reset/restart request
+      unsigned long request = ot_->buildRequest(OpenThermRequestType::WRITE, OpenThermMessageID::Command, 1);
+      unsigned long response = ot_->sendRequest(request);
+      return ot_->isValidResponse(response);
+    }
+
     void OpenthermComponent::processRequest(unsigned long request, OpenThermResponseStatus status)
     {
       if (instance_ != nullptr && instance_->ot_ != nullptr && instance_->slave_ot_ != nullptr)

--- a/components/opentherm/opentherm_component.h
+++ b/components/opentherm/opentherm_component.h
@@ -68,6 +68,9 @@ namespace esphome
       float getModulation();
       float getPressure();
 
+      // Restart the boiler via OpenTherm command
+      bool restart_boiler();
+
       // Process OpenTherm requests - needs to be static for the interrupt handler
       static void processRequest(unsigned long request, OpenThermResponseStatus status);
 

--- a/components/opentherm/sensor.py
+++ b/components/opentherm/sensor.py
@@ -9,7 +9,7 @@ from esphome.const import (
     UNIT_PERCENT,
     UNIT_HECTOPASCAL,
 )
-from . import opentherm_ns, OpenthermComponent, CONF_ID
+from . import OpenthermComponent, CONF_ID
 
 DEPENDENCIES = ["opentherm"]
 CODEOWNERS = ["@yourusername"]

--- a/example_opentherm.yaml
+++ b/example_opentherm.yaml
@@ -125,6 +125,10 @@ button:
   - platform: restart
     name: "${friendly_name} Restart"
     id: restart_button
+  - platform: template
+    name: "${friendly_name} Boiler Restart"
+    on_press:
+      - opentherm.restart_boiler
 
 # Add a couple of template sensors to show additional information (optional)
 sensor:


### PR DESCRIPTION
## Summary
- support boiler restart via OpenTherm command
- expose `restart_boiler` service in the component
- add example buttons and document usage

## Testing
- `ruff check`
- `pyright` *(fails: missing esphome modules)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7555d6dc832a894cb486fb61cf81