### PR TITLE
Add GitHub Community Standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or issue
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+A clear description of the bug.
+
+## Environment
+- **ESPHome Version**: [e.g., 2025.12.4]
+- **Hardware**: [ESP8266/ESP32, adapter model]
+- **Boiler Model**: [manufacturer and model]
+
+## Configuration
+```yaml
+# Paste relevant YAML configuration
+opentherm:
+  id: opentherm_gateway
+  # ...
+```
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Logs
+```
+Paste DEBUG logs here (logger: level: DEBUG)
+```
+
+## Additional Context
+Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,37 +1,23 @@
 ---
 name: Bug Report
-about: Report a bug or issue
+about: Report a bug
 title: '[BUG] '
 labels: bug
-assignees: ''
 ---
 
-## Description
-A clear description of the bug.
-
 ## Environment
-- **ESPHome Version**: [e.g., 2025.12.4]
-- **Hardware**: [ESP8266/ESP32, adapter model]
-- **Boiler Model**: [manufacturer and model]
+- ESPHome version:
+- Hardware (ESP8266/ESP32):
+- Boiler model:
 
-## Configuration
+## Description
+What happened vs what you expected.
+
+## Config & Logs
 ```yaml
-# Paste relevant YAML configuration
-opentherm:
-  id: opentherm_gateway
-  # ...
+# Paste relevant config
 ```
 
-## Expected Behavior
-What you expected to happen.
-
-## Actual Behavior
-What actually happened.
-
-## Logs
 ```
-Paste DEBUG logs here (logger: level: DEBUG)
+# Paste DEBUG logs (logger: level: DEBUG)
 ```
-
-## Additional Context
-Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,25 +1,15 @@
 ---
 name: Feature Request
-about: Suggest a new feature or enhancement
+about: Suggest a feature
 title: '[FEATURE] '
 labels: enhancement
-assignees: ''
 ---
 
-## Feature Description
-Clear description of the proposed feature.
+## Feature
+What feature would you like?
 
 ## Use Case
-Explain the problem this feature would solve or the benefit it would provide.
+What problem does this solve?
 
-## Proposed Solution
-How you envision this feature working (optional).
-
-## Alternatives Considered
-Other approaches you've considered (optional).
-
-## OpenTherm Compatibility
-If this relates to OpenTherm protocol, specify relevant Data IDs or message types (optional).
-
-## Additional Context
-Any other relevant information, screenshots, or examples.
+## Notes
+Any technical details (OpenTherm Data IDs, etc.)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+Clear description of the proposed feature.
+
+## Use Case
+Explain the problem this feature would solve or the benefit it would provide.
+
+## Proposed Solution
+How you envision this feature working (optional).
+
+## Alternatives Considered
+Other approaches you've considered (optional).
+
+## OpenTherm Compatibility
+If this relates to OpenTherm protocol, specify relevant Data IDs or message types (optional).
+
+## Additional Context
+Any other relevant information, screenshots, or examples.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,7 @@
-## Description
-Brief description of changes.
-
-## Type of Change
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Documentation update
-- [ ] Code refactoring
-- [ ] Other (specify):
-
-## Changes Made
-- List key changes
-- One per line
+## Changes
+Brief description of what changed.
 
 ## Testing
-Describe how you tested these changes:
-- [ ] Builds successfully (`esphome compile build.yaml`)
-- [ ] Tested on hardware (specify: ESP8266/ESP32)
-- [ ] Verified in Home Assistant
-- [ ] Checked logs for errors
-
-**Hardware tested on:**
-- ESP:
-- Adapter:
-- Boiler:
-
-## Documentation
-- [ ] Updated `Readme.md` (if user-facing changes)
-- [ ] Updated `CLAUDE.md` (if architectural changes)
-- [ ] Updated `example_opentherm.yaml` (if new config options)
-
-## Checklist
-- [ ] Code follows existing style
-- [ ] No unrelated changes included
-- [ ] Commit messages are clear and descriptive
-- [ ] All tests pass
-
-## Additional Notes
-Any other context or information.
+- [ ] Builds (`esphome compile build.yaml`)
+- [ ] Tested on hardware: [ESP8266/ESP32, boiler model]
+- [ ] Docs updated if needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Description
+Brief description of changes.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Other (specify):
+
+## Changes Made
+- List key changes
+- One per line
+
+## Testing
+Describe how you tested these changes:
+- [ ] Builds successfully (`esphome compile build.yaml`)
+- [ ] Tested on hardware (specify: ESP8266/ESP32)
+- [ ] Verified in Home Assistant
+- [ ] Checked logs for errors
+
+**Hardware tested on:**
+- ESP:
+- Adapter:
+- Boiler:
+
+## Documentation
+- [ ] Updated `Readme.md` (if user-facing changes)
+- [ ] Updated `CLAUDE.md` (if architectural changes)
+- [ ] Updated `example_opentherm.yaml` (if new config options)
+
+## Checklist
+- [ ] Code follows existing style
+- [ ] No unrelated changes included
+- [ ] Commit messages are clear and descriptive
+- [ ] All tests pass
+
+## Additional Notes
+Any other context or information.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: prev_tag
+        run: |
+          PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+          echo "prev_tag=${PREV_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          if [ -n "${{ steps.prev_tag.outputs.prev_tag }}" ]; then
+            NOTES=$(git log ${{ steps.prev_tag.outputs.prev_tag }}..${{ github.ref_name }} --pretty=format:"- %s" --no-merges)
+          else
+            NOTES=$(git log ${{ github.ref_name }} --pretty=format:"- %s" --no-merges | head -20)
+          fi
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            ## Changes
+
+            ${{ steps.notes.outputs.notes }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to providing a welcoming and inclusive environment for all contributors, regardless of experience level, background, or identity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful and professional
+- Providing constructive feedback
+- Focusing on what's best for the project and community
+- Showing empathy and kindness
+
+Examples of unacceptable behavior:
+
+- Harassment, discrimination, or offensive comments
+- Personal attacks or insults
+- Trolling or deliberately disruptive behavior
+- Publishing others' private information without permission
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainers. All complaints will be reviewed and investigated.
+
+Project maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including GitHub repositories, issue trackers, and any community interactions related to the project.
+
+## Attribution
+
+This Code of Conduct is adapted from community standards and best practices.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,35 +1,11 @@
 # Code of Conduct
 
-## Our Pledge
+## Standards
 
-We are committed to providing a welcoming and inclusive environment for all contributors, regardless of experience level, background, or identity.
-
-## Our Standards
-
-Examples of behavior that contributes to a positive environment:
-
-- Being respectful and professional
-- Providing constructive feedback
-- Focusing on what's best for the project and community
-- Showing empathy and kindness
-
-Examples of unacceptable behavior:
-
-- Harassment, discrimination, or offensive comments
-- Personal attacks or insults
-- Trolling or deliberately disruptive behavior
-- Publishing others' private information without permission
+- Be respectful and professional
+- Provide constructive feedback
+- No harassment or personal attacks
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainers. All complaints will be reviewed and investigated.
-
-Project maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct.
-
-## Scope
-
-This Code of Conduct applies to all project spaces, including GitHub repositories, issue trackers, and any community interactions related to the project.
-
-## Attribution
-
-This Code of Conduct is adapted from community standards and best practices.
+Report unacceptable behavior by opening an issue. Maintainers may remove inappropriate content.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,20 @@
-# Contributing to ESPHome OpenTherm Gateway
+# Contributing
 
-Thank you for your interest in contributing! This project welcomes contributions from the community.
+## Bug Reports
 
-## How to Contribute
+Open an issue with:
+- ESPHome version, hardware (ESP8266/ESP32), boiler model
+- Config YAML and DEBUG logs
+- Expected vs actual behavior
 
-### Reporting Bugs
+## Pull Requests
 
-If you find a bug, please open an issue with:
-- **ESPHome version** you're using
-- **Hardware** (ESP8266/ESP32, OpenTherm adapter model)
-- **Boiler model** and configuration
-- **Configuration YAML** (relevant parts)
-- **Log output** with `logger: level: DEBUG`
-- **Expected vs actual behavior**
+- Test with `esphome compile build.yaml`
+- Follow existing code style
+- Update docs if needed
 
-### Suggesting Features
-
-Feature suggestions are welcome! Please:
-- Check existing issues first to avoid duplicates
-- Describe the use case and benefit
-- Consider if it fits the project scope (OpenTherm gateway functionality)
-
-### Pull Requests
-
-1. **Fork** the repository
-2. **Create a branch** for your feature/fix
-3. **Test thoroughly** with your hardware setup
-4. **Follow existing code style**:
-   - C++: Match existing formatting in `.cpp`/`.h` files
-   - Python: Follow ESPHome component patterns
-5. **Update documentation**:
-   - Update `Readme.md` if adding user-facing features
-   - Update `CLAUDE.md` if changing architecture
-   - Add config examples to `example_opentherm.yaml`
-6. **Commit messages**: Clear, descriptive (e.g., "Add support for X sensor")
-7. **Create PR** with description of changes and testing done
-
-### Testing
-
-Before submitting:
-- Build successfully: `esphome compile build.yaml`
-- Test on actual hardware if possible
-- Check logs for errors/warnings
-- Verify Home Assistant integration works
-
-### Development Setup
-
-See [`CLAUDE.md`](CLAUDE.md) for:
-- Component architecture details
-- OpenTherm protocol documentation
-- Build/test commands
-- Debugging tips
-
-## Code Review Process
-
-- PRs will be reviewed for code quality, testing, and compatibility
-- Feedback may be provided for improvements
-- Once approved, changes will be merged
-
-## Questions?
-
-- Open an issue for questions about contributing
-- Check existing issues and documentation first
+See [`CLAUDE.md`](CLAUDE.md) for development details.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+Contributions are licensed under MIT License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to ESPHome OpenTherm Gateway
+
+Thank you for your interest in contributing! This project welcomes contributions from the community.
+
+## How to Contribute
+
+### Reporting Bugs
+
+If you find a bug, please open an issue with:
+- **ESPHome version** you're using
+- **Hardware** (ESP8266/ESP32, OpenTherm adapter model)
+- **Boiler model** and configuration
+- **Configuration YAML** (relevant parts)
+- **Log output** with `logger: level: DEBUG`
+- **Expected vs actual behavior**
+
+### Suggesting Features
+
+Feature suggestions are welcome! Please:
+- Check existing issues first to avoid duplicates
+- Describe the use case and benefit
+- Consider if it fits the project scope (OpenTherm gateway functionality)
+
+### Pull Requests
+
+1. **Fork** the repository
+2. **Create a branch** for your feature/fix
+3. **Test thoroughly** with your hardware setup
+4. **Follow existing code style**:
+   - C++: Match existing formatting in `.cpp`/`.h` files
+   - Python: Follow ESPHome component patterns
+5. **Update documentation**:
+   - Update `Readme.md` if adding user-facing features
+   - Update `CLAUDE.md` if changing architecture
+   - Add config examples to `example_opentherm.yaml`
+6. **Commit messages**: Clear, descriptive (e.g., "Add support for X sensor")
+7. **Create PR** with description of changes and testing done
+
+### Testing
+
+Before submitting:
+- Build successfully: `esphome compile build.yaml`
+- Test on actual hardware if possible
+- Check logs for errors/warnings
+- Verify Home Assistant integration works
+
+### Development Setup
+
+See [`CLAUDE.md`](CLAUDE.md) for:
+- Component architecture details
+- OpenTherm protocol documentation
+- Build/test commands
+- Debugging tips
+
+## Code Review Process
+
+- PRs will be reviewed for code quality, testing, and compatibility
+- Feedback may be provided for improvements
+- Once approved, changes will be merged
+
+## Questions?
+
+- Open an issue for questions about contributing
+- Check existing issues and documentation first
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sakrut
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+## Supported Versions
+
+This project follows ESPHome's release cycle. We recommend using the latest version.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please:
+
+1. **DO NOT** open a public issue
+2. **Email** the maintainer directly (check GitHub profile for contact)
+3. **Include**:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+## Security Considerations
+
+### Network Security
+- This component communicates with Home Assistant via WiFi
+- Ensure your ESPHome device is on a trusted network
+- Use strong WiFi passwords and encryption (WPA2/WPA3)
+- Consider network segmentation for IoT devices
+
+### Physical Security
+- The component controls heating systems
+- Ensure physical access to the ESP device is restricted
+- Use ESPHome's `api:` encryption and password protection
+- Enable `ota:` password for firmware updates
+
+### Recommended Configuration
+
+```yaml
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+```
+
+## Known Limitations
+
+- This is a hardware gateway component - ensure proper electrical safety
+- The component intercepts OpenTherm communication - test thoroughly before deployment
+- Boiler control carries inherent risks - use at your own risk
+
+## Updates
+
+Security updates will be released as needed. Monitor the repository for updates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,61 +1,16 @@
 # Security Policy
 
-## Supported Versions
+## Reporting Vulnerabilities
 
-This project follows ESPHome's release cycle. We recommend using the latest version.
+**DO NOT** open public issues for security vulnerabilities.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| Latest  | :white_check_mark: |
-| Older   | :x:                |
+Email the maintainer directly (check GitHub profile) with:
+- Description and steps to reproduce
+- Potential impact
 
-## Reporting a Vulnerability
+## Security Best Practices
 
-If you discover a security vulnerability, please:
-
-1. **DO NOT** open a public issue
-2. **Email** the maintainer directly (check GitHub profile for contact)
-3. **Include**:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
-
-## Security Considerations
-
-### Network Security
-- This component communicates with Home Assistant via WiFi
-- Ensure your ESPHome device is on a trusted network
-- Use strong WiFi passwords and encryption (WPA2/WPA3)
-- Consider network segmentation for IoT devices
-
-### Physical Security
-- The component controls heating systems
-- Ensure physical access to the ESP device is restricted
-- Use ESPHome's `api:` encryption and password protection
-- Enable `ota:` password for firmware updates
-
-### Recommended Configuration
-
-```yaml
-api:
-  encryption:
-    key: !secret api_encryption_key
-
-ota:
-  password: !secret ota_password
-
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-```
-
-## Known Limitations
-
-- This is a hardware gateway component - ensure proper electrical safety
-- The component intercepts OpenTherm communication - test thoroughly before deployment
-- Boiler control carries inherent risks - use at your own risk
-
-## Updates
-
-Security updates will be released as needed. Monitor the repository for updates.
+- Use ESPHome API encryption and OTA passwords
+- Keep devices on trusted networks (WPA2/WPA3)
+- Test thoroughly - this controls heating systems
+- Monitor for updates


### PR DESCRIPTION
## Changes

Adds GitHub Community Standards with minimalist approach:

### Files Added
- **LICENSE** - MIT License for open-source usage
- **CODE_OF_CONDUCT.md** - Basic community guidelines (11 lines)
- **CONTRIBUTING.md** - Contribution guide (20 lines)
- **SECURITY.md** - Security policy (16 lines)
- **Issue templates** - Bug report and feature request
- **PR template** - Simple checklist
- **Release workflow** - Automated GitHub releases on tag push

### Automated Versioning
The release workflow (`.github/workflows/release.yml`) will automatically:
- Trigger on version tags (e.g., `v2.0.0`)
- Generate release notes from commit messages
- Create GitHub releases

### Next Steps
After merging, ready to tag v2.0.0 for recent major improvements:
- Climate target temperature persistence fix
- Smart caching (80-90% traffic reduction)
- Boiler reset button
- Diagnostic sensors
- Comprehensive documentation
